### PR TITLE
fix(engine,control,luts): Switch to a 30A (30% taper) pot to provide …

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl Default for TheTweed {
             amp_topology: AmpTopology::new(sample_rate, build_5e3_amp_topology_config()),
 
             // 5E3 volume pots: 1MΩ CTS 15A audio taper (both channels identical)
-            volume_taper: PotTaperConfig::new(PotTaper::Audio15A),
+            volume_taper: PotTaperConfig::new(PotTaper::Audio30A),
 
             speaker_normalizer: SpeakerNormalizer::from_speaker_model(SpeakerModel::JensenP),
 


### PR DESCRIPTION
…more volume control, this results in earlier breakup since the curve is flatter and the volume increases earlier in the wipers rotation. LUT's were regenerated to include some fixes and a wider SavGol window.